### PR TITLE
[DRAFT] Fix fragmented mp4 with composition offset having too short duration

### DIFF
--- a/include/gpac/internal/isomedia_dev.h
+++ b/include/gpac/internal/isomedia_dev.h
@@ -4339,6 +4339,8 @@ GF_Box *gf_isom_clone_config_box(GF_Box *box);
 GF_Err gf_isom_box_dump(void *ptr, FILE * trace);
 GF_Err gf_isom_box_array_dump(GF_List *list, FILE * trace);
 
+u64 gf_moof_get_earliest_cts(GF_MovieFragmentBox *moof, GF_ISOTrackID refTrackID);
+
 void gf_isom_registry_disable(u32 boxCode, Bool disable);
 
 /*Apple extensions*/

--- a/src/isomedia/movie_fragments.c
+++ b/src/isomedia/movie_fragments.c
@@ -846,7 +846,7 @@ u32 moof_get_duration(GF_MovieFragmentBox *moof, GF_ISOTrackID refTrackID)
 	return duration;
 }
 
-static u64 moof_get_earliest_cts(GF_MovieFragmentBox *moof, GF_ISOTrackID refTrackID)
+u64 gf_moof_get_earliest_cts(GF_MovieFragmentBox *moof, GF_ISOTrackID refTrackID)
 {
 	u32 i, j;
 	u64 cts, duration;
@@ -1709,7 +1709,7 @@ GF_Err gf_isom_close_segment(GF_ISOFile *movie, s32 subsegments_per_sidx, GF_ISO
 	if (referenceTrackID) {
 		Bool is_root_sidx = GF_FALSE;
 
-		prev_earliest_cts = get_presentation_time( ref_track_decode_time + moof_get_earliest_cts((GF_MovieFragmentBox*)gf_list_get(movie->moof_list, 0), referenceTrackID), ts_shift);
+		prev_earliest_cts = get_presentation_time( ref_track_decode_time + gf_moof_get_earliest_cts((GF_MovieFragmentBox*)gf_list_get(movie->moof_list, 0), referenceTrackID), ts_shift);
 
 		//we don't trust ref_track_next_cts to be the earliest in the following segment
 		next_earliest_cts = estimate_next_moof_earliest_presentation_time(ref_track_decode_time, ts_shift, referenceTrackID, movie);
@@ -1873,7 +1873,7 @@ GF_Err gf_isom_close_segment(GF_ISOFile *movie, s32 subsegments_per_sidx, GF_ISO
 			if (!sidx) return GF_OUT_OF_MEM;
 			sidx->reference_ID = referenceTrackID;
 			sidx->timescale = trak ? trak->Media->mediaHeader->timeScale : 1000;
-			sidx->earliest_presentation_time = get_presentation_time( ref_track_decode_time + sidx_dur + moof_get_earliest_cts(movie->moof, referenceTrackID), ts_shift);
+			sidx->earliest_presentation_time = get_presentation_time( ref_track_decode_time + sidx_dur + gf_moof_get_earliest_cts(movie->moof, referenceTrackID), ts_shift);
 
 			frag_count = frags_per_subsidx;
 
@@ -1942,7 +1942,7 @@ GF_Err gf_isom_close_segment(GF_ISOFile *movie, s32 subsegments_per_sidx, GF_ISO
 
 				/*do not compute earliest CTS if single segment sidx since we only have set the info for one subsegment*/
 				if (!movie->root_sidx && first_frag_in_subseg) {
-					u64 first_cts = get_presentation_time( ref_track_decode_time + sidx_dur + cur_dur +  moof_get_earliest_cts(movie->moof, referenceTrackID), ts_shift);
+					u64 first_cts = get_presentation_time( ref_track_decode_time + sidx_dur + cur_dur +  gf_moof_get_earliest_cts(movie->moof, referenceTrackID), ts_shift);
 					if (cur_index) {
 						u32 subseg_dur = (u32) (first_cts - prev_earliest_cts);
 						sidx->refs[cur_index-1].subsegment_duration = subseg_dur;
@@ -2026,7 +2026,7 @@ GF_Err gf_isom_close_segment(GF_ISOFile *movie, s32 subsegments_per_sidx, GF_ISO
 					if ((next_earliest_cts==-1) || (next_earliest_cts < prev_earliest_cts))  {
 						u64 next_cts;
 						if (gf_list_count(movie->moof_list)) {
-							next_cts = get_presentation_time( ref_track_decode_time + sidx_dur + cur_dur + moof_get_earliest_cts((GF_MovieFragmentBox*)gf_list_get(movie->moof_list, 0), referenceTrackID), ts_shift);
+							next_cts = get_presentation_time( ref_track_decode_time + sidx_dur + cur_dur + gf_moof_get_earliest_cts((GF_MovieFragmentBox*)gf_list_get(movie->moof_list, 0), referenceTrackID), ts_shift);
 						} else {
 							next_cts = get_presentation_time( ref_track_next_cts, ts_shift);
 						}

--- a/src/isomedia/track.c
+++ b/src/isomedia/track.c
@@ -801,8 +801,10 @@ GF_Err MergeTrack(GF_TrackBox *trak, GF_TrackFragmentBox *traf, GF_MovieFragment
 			}
 			else if (!edts_e->segmentDuration) {
 				edts_e->was_empty_dur = GF_TRUE;
-				if ((s64) traf_duration > edts_e->mediaTime)
-					traf_duration -= edts_e->mediaTime;
+				s64 earliest_cts = (s64)gf_moof_get_earliest_cts(moof_box, trak->Header->trackID);
+				s64 offs = edts_e->mediaTime - earliest_cts;
+				if ((s64) traf_duration > offs)
+					traf_duration -= offs;
 				else
 					traf_duration = 0;
 


### PR DESCRIPTION
When remuxing a fragmented MP4 that uses B-frames with MP4Box, the duration of the resulting file becomes too short. The amount of missing frames at the end is the same as the number of B-frames.

Reproduction steps:

First, generate a fragmented MP4 with ffmpeg (the version I used was 4.4.1 installed from Brew on OSX). The duration is 1 second/25 frames.

```
ffmpeg -y -f lavfi -i "testsrc=duration=1s" -pix_fmt yuv420p -c:v libx264 -profile high -bf 2 -movflags frag_keyframe+empty_moov+delay_moov+skip_trailer fragmented.mp4
```

Then, remux it with MP4Box (v. 1.0.1):
``` 
MP4Box -add fragmented.mp4 -new remuxed.mp4
```

The resulting `remuxed.mp4` file now has an edit list entry with segment_duration set to 0.92 seconds, i.e. it’s missing two 40ms-frames.


The issue appears to be in the calculation of the `traf` duration in the `MergeTrack()` function. It subtracts the media_time of the source file edit list entry from its duration, but it does not compensate for the fact that the composition start time of the video track may not be 0 when B-frames are used. In this particular example, the source video track starts at composition time 1024 (each frame has duration 512 time base units). Since the source edit list entry media_time is 1024 as well, it means that it effectively points to the very beginning of the video track.

To solve this, I believe that the composition start time should be subtracted from the media_time, and that result is what should be subtracted from the duration. Continuing on the example, this means that the edit list entry media_time and video track start times precisely cancel each other out, and nothing is subtracted from the duration.

The supplied patch implements this logic, by repurposing the already existing `gf_moof_get_earliest_cts()` function from `isomedia/movie_fragments.c` in order to find the correct composition start offset. I don’t have any previous experience with this code base, so I’m not sure if this is a good way to solve things architecturally. I’d be happy to take suggestions for alternatives if not.